### PR TITLE
feat: client certs, CRUD improvements, cert details, bug fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,6 @@ import ipaddress
 from flask import Flask, render_template, request, redirect, url_for, flash, send_from_directory
 from dotenv import load_dotenv
 
-# Cryptography imports
 from cryptography import x509
 from cryptography.x509.oid import NameOID, ExtendedKeyUsageOID
 from cryptography.hazmat.primitives import hashes, serialization
@@ -21,14 +20,13 @@ CERT_DIR = os.getenv('CERT_DIR', './certs')
 ROOT_DIR = os.getenv('ROOT_DIR', './rootCA')
 ROOT_CA_NAME = os.getenv('ROOT_CA_NAME', 'rootca')
 
-# Ensure dirs exist
 os.makedirs(CERT_DIR, exist_ok=True)
 os.makedirs(ROOT_DIR, exist_ok=True)
 
-# --- Helper Functions ---
+
+# --- Helpers ---
 
 def save_key(key, path):
-    """Saves a private key to disk."""
     with open(path, "wb") as f:
         f.write(key.private_bytes(
             encoding=serialization.Encoding.PEM,
@@ -37,48 +35,163 @@ def save_key(key, path):
         ))
 
 def load_key(path, password=None):
-    """Loads a private key from disk."""
     with open(path, "rb") as f:
-        # Encode password to bytes if provided
         pwd_bytes = password.encode('utf-8') if password else None
         return serialization.load_pem_private_key(f.read(), password=pwd_bytes)
 
 def save_cert(cert, path):
-    """Saves a certificate to disk."""
     with open(path, "wb") as f:
         f.write(cert.public_bytes(serialization.Encoding.PEM))
 
 def load_cert(path):
-    """Loads a certificate from disk."""
     with open(path, "rb") as f:
         return x509.load_pem_x509_certificate(f.read())
 
 def load_csr(path):
-    """Loads a CSR from disk."""
     with open(path, "rb") as f:
         return x509.load_pem_x509_csr(f.read())
 
+def cert_not_after(cert):
+    try:
+        return cert.not_valid_after_utc
+    except AttributeError:
+        return cert.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+
+def cert_not_before(cert):
+    try:
+        return cert.not_valid_before_utc
+    except AttributeError:
+        return cert.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+
 def get_sans_from_ext_content(content):
-    """
-    Parses the user-editable text content to extract DNS and IP SANs.
-    """
     sans = []
-    lines = content.splitlines()
-    for line in lines:
+    for line in content.splitlines():
         line = line.strip()
         if line.upper().startswith("DNS"):
-            parts = line.split('=')
+            parts = line.split('=', 1)
             if len(parts) > 1:
                 sans.append(x509.DNSName(parts[1].strip()))
         elif line.upper().startswith("IP"):
-            parts = line.split('=')
+            parts = line.split('=', 1)
             if len(parts) > 1:
                 try:
-                    ip = ipaddress.ip_address(parts[1].strip())
-                    sans.append(x509.IPAddress(ip))
+                    sans.append(x509.IPAddress(ipaddress.ip_address(parts[1].strip())))
                 except ValueError:
-                    pass 
+                    pass
+        elif line.upper().startswith("EMAIL"):
+            parts = line.split('=', 1)
+            if len(parts) > 1:
+                sans.append(x509.RFC822Name(parts[1].strip()))
     return sans
+
+def get_cert_type(cert_dir):
+    type_file = os.path.join(cert_dir, 'cert.type')
+    if os.path.exists(type_file):
+        with open(type_file, 'r') as f:
+            return f.read().strip()
+    return 'server'
+
+def parse_cert_details(crt_path):
+    try:
+        cert = load_cert(crt_path)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        not_after = cert_not_after(cert)
+        not_before = cert_not_before(cert)
+        days_left = (not_after - now).days
+
+        subject_cn = next(
+            (a.value for a in cert.subject if a.oid == NameOID.COMMON_NAME), ''
+        )
+        issuer_cn = next(
+            (a.value for a in cert.issuer if a.oid == NameOID.COMMON_NAME), ''
+        )
+
+        sans = []
+        try:
+            san_ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+            for san in san_ext.value:
+                if isinstance(san, x509.DNSName):
+                    sans.append(f"DNS: {san.value}")
+                elif isinstance(san, x509.IPAddress):
+                    sans.append(f"IP: {san.value}")
+                elif isinstance(san, x509.RFC822Name):
+                    sans.append(f"email: {san.value}")
+        except x509.ExtensionNotFound:
+            pass
+
+        eku = []
+        try:
+            eku_ext = cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage)
+            for usage in eku_ext.value:
+                if usage == ExtendedKeyUsageOID.SERVER_AUTH:
+                    eku.append('serverAuth')
+                elif usage == ExtendedKeyUsageOID.CLIENT_AUTH:
+                    eku.append('clientAuth')
+        except x509.ExtensionNotFound:
+            pass
+
+        return {
+            'subject_cn': subject_cn,
+            'issuer_cn': issuer_cn,
+            'not_before': not_before.strftime('%Y-%m-%d %H:%M UTC'),
+            'not_after': not_after.strftime('%Y-%m-%d %H:%M UTC'),
+            'days_left': days_left,
+            'serial': format(cert.serial_number, 'X'),
+            'sans': sans,
+            'eku': eku,
+        }
+    except Exception:
+        return None
+
+def _build_cert(csr, issuer_name, issuer_public_key, signing_key, days, cert_type, ext_path):
+    is_client = cert_type == 'client'
+
+    key_usage = x509.KeyUsage(
+        digital_signature=True,
+        content_commitment=False,
+        key_encipherment=not is_client,
+        data_encipherment=False,
+        key_agreement=False,
+        key_cert_sign=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False,
+    )
+    eku_oid = ExtendedKeyUsageOID.CLIENT_AUTH if is_client else ExtendedKeyUsageOID.SERVER_AUTH
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(issuer_name)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=days))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(key_usage, critical=True)
+        .add_extension(x509.ExtendedKeyUsage([eku_oid]), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(issuer_public_key),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+            critical=False,
+        )
+    )
+
+    if os.path.exists(ext_path):
+        with open(ext_path, 'r') as f:
+            content = f.read()
+        sans = get_sans_from_ext_content(content)
+        if sans:
+            builder = builder.add_extension(
+                x509.SubjectAlternativeName(sans), critical=False
+            )
+
+    return builder.sign(signing_key, hashes.SHA256())
+
 
 # --- Routes ---
 
@@ -88,64 +201,97 @@ def home_redirect():
 
 @app.route('/cert/')
 def index():
-    # 1. Get List of Cert Folders
-    cert_dirs = [d for d in os.listdir(CERT_DIR) if os.path.isdir(os.path.join(CERT_DIR, d))]
-    
-    # 2. Check Root CA
+    cert_dirs = sorted(
+        d for d in os.listdir(CERT_DIR) if os.path.isdir(os.path.join(CERT_DIR, d))
+    )
+
     root_crt_path = os.path.join(ROOT_DIR, f"{ROOT_CA_NAME}.crt")
     root_exists = os.path.exists(root_crt_path)
-    
     root_subject = None
+    root_info = None
+
     if root_exists:
         try:
-            root_cert_obj = load_cert(root_crt_path)
-            root_subject = root_cert_obj.subject
-        except:
-            pass # Handle corrupted root cert gracefully
+            root_cert = load_cert(root_crt_path)
+            root_subject = root_cert.subject
+            now = datetime.datetime.now(datetime.timezone.utc)
+            not_after = cert_not_after(root_cert)
+            cn_attrs = root_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+            root_info = {
+                'cn': cn_attrs[0].value if cn_attrs else ROOT_CA_NAME,
+                'not_after': not_after.strftime('%Y-%m-%d'),
+                'days_left': (not_after - now).days,
+            }
+        except Exception:
+            pass
 
-    # 3. Analyze Certificates for Status Colors
     analyzed_certs = []
-    
     for fqdn in cert_dirs:
-        crt_path = os.path.join(CERT_DIR, fqdn, f"{fqdn}.crt")
-        status = "pending" # Default if no CRT exists
-        
+        cert_dir = os.path.join(CERT_DIR, fqdn)
+        crt_path = os.path.join(cert_dir, f"{fqdn}.crt")
+        status = "pending"
+        not_after_str = None
+        days_left = None
+        cert_type = get_cert_type(cert_dir)
+
         if os.path.exists(crt_path):
             try:
                 cert_obj = load_cert(crt_path)
-                issuer = cert_obj.issuer
-                subject = cert_obj.subject
-                
-                if issuer == subject:
-                    status = "blue" # Self-signed
-                elif root_subject and issuer == root_subject:
-                    status = "green" # Signed by OUR Root
+                now = datetime.datetime.now(datetime.timezone.utc)
+                not_after = cert_not_after(cert_obj)
+                days_left = (not_after - now).days
+                not_after_str = not_after.strftime('%Y-%m-%d')
+
+                if cert_obj.issuer == cert_obj.subject:
+                    status = "blue"
+                elif root_subject and cert_obj.issuer == root_subject:
+                    status = "green"
                 else:
-                    status = "red" # Signed by unknown
+                    status = "red"
             except Exception:
-                status = "error" # Corrupt file
-        
+                status = "error"
+
         analyzed_certs.append({
             'fqdn': fqdn,
-            'status': status
+            'status': status,
+            'cert_type': cert_type,
+            'not_after': not_after_str,
+            'days_left': days_left,
         })
 
-    return render_template('index.html', 
-                           certs=analyzed_certs, 
-                           root_exists=root_exists, 
-                           root_filename=f"{ROOT_CA_NAME}.crt")
+    return render_template('index.html',
+                           certs=analyzed_certs,
+                           root_exists=root_exists,
+                           root_filename=f"{ROOT_CA_NAME}.crt",
+                           root_info=root_info)
 
 @app.route('/cert/download_root')
 def download_root():
     return send_from_directory(ROOT_DIR, f"{ROOT_CA_NAME}.crt", as_attachment=True)
 
+@app.route('/cert/download/<fqdn>/<filetype>')
+def download_cert_file(fqdn, filetype):
+    allowed = {'crt', 'key', 'csr', 'p12'}
+    if filetype not in allowed:
+        flash('Invalid file type.', 'error')
+        return redirect(url_for('manage_cert', fqdn=fqdn))
+
+    cert_dir = os.path.join(CERT_DIR, fqdn)
+    filename = f"{fqdn}.{filetype}"
+    file_path = os.path.join(cert_dir, filename)
+
+    if not os.path.exists(file_path):
+        flash(f'{filetype.upper()} file not found.', 'error')
+        return redirect(url_for('manage_cert', fqdn=fqdn))
+
+    return send_from_directory(cert_dir, filename, as_attachment=True)
+
 @app.route('/cert/create_root', methods=['GET', 'POST'])
 def create_root():
     if request.method == 'GET':
-        return render_template('create_root.html')
+        return render_template('create_root.html', prefill_cn=request.args.get('cn', ''))
 
-    # Handle POST request: Process the form
-    cn = request.form.get('cn', 'My Internal rootCA').strip()
+    cn = request.form.get('cn', 'My Internal Root CA').strip()
     c = request.form.get('c', 'NL').strip()
     days = int(request.form.get('days', '3650'))
     email = request.form.get('email', '').strip()
@@ -154,67 +300,57 @@ def create_root():
     st = request.form.get('st', '').strip()
     city = request.form.get('city', '').strip()
     password = request.form.get('password', '').strip()
-        
+
     key_file = os.path.join(ROOT_DIR, f"{ROOT_CA_NAME}.key")
     crt_file = os.path.join(ROOT_DIR, f"{ROOT_CA_NAME}.crt")
 
     try:
-        # 2. Generate Private Key
-        private_key = rsa.generate_private_key(
-            public_exponent=65537,
-            key_size=4096,
-        )
-        if password:
-            algorithm = serialization.BestAvailableEncryption(password.encode('utf-8'))    
-        else:
-            algorithm = serialization.NoEncryption()
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
 
-        pem_key = private_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=algorithm
+        algorithm = (
+            serialization.BestAvailableEncryption(password.encode('utf-8'))
+            if password else serialization.NoEncryption()
         )
-        
         with open(key_file, "wb") as f:
-            f.write(pem_key)
+            f.write(private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=algorithm,
+            ))
 
-        # 3. Build the Subject Name dynamically
-        name_attributes = [x509.NameAttribute(NameOID.COMMON_NAME, cn)]
-        name_attributes.append(x509.NameAttribute(NameOID.COUNTRY_NAME, c))
-        if st: name_attributes.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, st))
-        if city: name_attributes.append(x509.NameAttribute(NameOID.LOCALITY_NAME, city))
-        if org: name_attributes.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, org))
-        if org_unit: name_attributes.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, org_unit))
-        if email: name_attributes.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, email))
+        name_attrs = [
+            x509.NameAttribute(NameOID.COMMON_NAME, cn),
+            x509.NameAttribute(NameOID.COUNTRY_NAME, c),
+        ]
+        if st:       name_attrs.append(x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, st))
+        if city:     name_attrs.append(x509.NameAttribute(NameOID.LOCALITY_NAME, city))
+        if org:      name_attrs.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, org))
+        if org_unit: name_attrs.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, org_unit))
+        if email:    name_attrs.append(x509.NameAttribute(NameOID.EMAIL_ADDRESS, email))
+        subject = x509.Name(name_attrs)
 
-        subject = x509.Name(name_attributes)
-
-        builder = x509.CertificateBuilder()
-        builder = builder.subject_name(subject)
-        builder = builder.issuer_name(subject)
-        builder = builder.public_key(private_key.public_key())
-        builder = builder.serial_number(x509.random_serial_number())
-        builder = builder.not_valid_before(datetime.datetime.utcnow())
-        builder = builder.not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=days))
-
-        builder = builder.add_extension(
-            x509.BasicConstraints(ca=True, path_length=None), critical=True,
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(private_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + datetime.timedelta(days=days))
+            .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(private_key.public_key()),
+                critical=False,
+            )
+            .sign(private_key=private_key, algorithm=hashes.SHA256())
         )
-        builder = builder.add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(private_key.public_key()),
-            critical=False,
-        )
-
-        cert = builder.sign(
-            private_key=private_key, algorithm=hashes.SHA256()
-        )
-
         save_cert(cert, crt_file)
         flash('Root CA created successfully.', 'success')
 
     except Exception as e:
         flash(f'Error creating Root CA: {str(e)}', 'error')
-        
+
     return redirect(url_for('index'))
 
 @app.route('/cert/create', methods=['GET', 'POST'])
@@ -224,61 +360,72 @@ def create_cert():
         c = request.form.get('c', 'NL').strip()
         o = request.form.get('o', 'Hiddenmaces.nl').strip()
         ou = request.form.get('ou', 'IT').strip()
-        
+        cert_type = request.form.get('cert_type', 'server')
+        if cert_type not in ('server', 'client'):
+            cert_type = 'server'
+
         if not fqdn:
             flash("FQDN is required", "error")
             return redirect(url_for('create_cert'))
 
-        cert_path = os.path.join(CERT_DIR, fqdn)
-        if os.path.exists(cert_path):
+        cert_dir = os.path.join(CERT_DIR, fqdn)
+        if os.path.exists(cert_dir):
             flash(f'Certificate for {fqdn} already exists.', 'error')
             return redirect(url_for('create_cert'))
-            
-        os.makedirs(cert_path)
-        
-        key_file = os.path.join(cert_path, f"{fqdn}.key")
-        csr_file = os.path.join(cert_path, f"{fqdn}.csr")
-        ext_file = os.path.join(cert_path, f"{fqdn}.v3.ext")
+
+        os.makedirs(cert_dir)
 
         try:
-            # 1. Create EXT file
-            ext_content = f"""authorityKeyIdentifier=keyid,issuer
-basicConstraints=CA:FALSE
-keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-extendedKeyUsage = serverAuth
-subjectAltName = @alt_names
+            with open(os.path.join(cert_dir, 'cert.type'), 'w') as f:
+                f.write(cert_type)
 
-[alt_names]
-DNS.1 = {fqdn}
-"""
-            with open(ext_file, 'w') as f:
+            if cert_type == 'client':
+                ext_content = (
+                    "authorityKeyIdentifier=keyid,issuer\n"
+                    "basicConstraints=CA:FALSE\n"
+                    "keyUsage = digitalSignature\n"
+                    "extendedKeyUsage = clientAuth\n"
+                    "subjectAltName = @alt_names\n"
+                    "\n[alt_names]\n"
+                    f"email.1 = {fqdn}\n"
+                )
+            else:
+                ext_content = (
+                    "authorityKeyIdentifier=keyid,issuer\n"
+                    "basicConstraints=CA:FALSE\n"
+                    "keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment\n"
+                    "extendedKeyUsage = serverAuth\n"
+                    "subjectAltName = @alt_names\n"
+                    "\n[alt_names]\n"
+                    f"DNS.1 = {fqdn}\n"
+                )
+
+            with open(os.path.join(cert_dir, f"{fqdn}.v3.ext"), 'w') as f:
                 f.write(ext_content)
 
-            # 2. Generate Key
             private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-            save_key(private_key, key_file)
+            save_key(private_key, os.path.join(cert_dir, f"{fqdn}.key"))
 
-            # 3. Generate CSR
             subject = x509.Name([
                 x509.NameAttribute(NameOID.COUNTRY_NAME, c),
                 x509.NameAttribute(NameOID.ORGANIZATION_NAME, o),
                 x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, ou),
                 x509.NameAttribute(NameOID.COMMON_NAME, fqdn),
             ])
-
             csr = (
                 x509.CertificateSigningRequestBuilder()
                 .subject_name(subject)
                 .sign(private_key, hashes.SHA256())
             )
-            
-            with open(csr_file, "wb") as f:
+            with open(os.path.join(cert_dir, f"{fqdn}.csr"), "wb") as f:
                 f.write(csr.public_bytes(serialization.Encoding.PEM))
 
-            flash(f'CSR and Key created for {fqdn}. Please Sign it now.', 'success')
+            label = "Client" if cert_type == "client" else "Server"
+            flash(f'{label} CSR and key created for {fqdn}. Please sign it now.', 'success')
             return redirect(url_for('manage_cert', fqdn=fqdn))
 
         except Exception as e:
+            shutil.rmtree(cert_dir, ignore_errors=True)
             flash(f'Error: {str(e)}', 'error')
             return redirect(url_for('index'))
 
@@ -286,33 +433,28 @@ DNS.1 = {fqdn}
 
 @app.route('/cert/manage/<fqdn>')
 def manage_cert(fqdn):
-    cert_path = os.path.join(CERT_DIR, fqdn)
-    
-    # Check if files exist
-    if not os.path.exists(cert_path):
+    cert_dir = os.path.join(CERT_DIR, fqdn)
+
+    if not os.path.exists(cert_dir):
         flash(f"Certificate {fqdn} not found.", "error")
         return redirect(url_for('index'))
 
-    ext_file = os.path.join(cert_path, f"{fqdn}.v3.ext")
-    csr_file = os.path.join(cert_path, f"{fqdn}.csr")
-    
+    ext_file = os.path.join(cert_dir, f"{fqdn}.v3.ext")
+    csr_file = os.path.join(cert_dir, f"{fqdn}.csr")
+    crt_file = os.path.join(cert_dir, f"{fqdn}.crt")
+
     ext_content = ""
     if os.path.exists(ext_file):
         with open(ext_file, 'r') as f:
             ext_content = f.read()
 
-    has_crt = os.path.exists(os.path.join(cert_path, f"{fqdn}.crt"))
-    has_p12 = os.path.exists(os.path.join(cert_path, f"{fqdn}.p12"))
+    has_crt = os.path.exists(crt_file)
+    has_p12 = os.path.exists(os.path.join(cert_dir, f"{fqdn}.p12"))
+    has_key = os.path.exists(os.path.join(cert_dir, f"{fqdn}.key"))
+    has_csr = os.path.exists(csr_file)
 
-    # Parse CSR to get current details
-    csr_details = {
-        'cn': fqdn,
-        'c': '',
-        'o': '',
-        'ou': ''
-    }
-    
-    if os.path.exists(csr_file):
+    csr_details = {'cn': fqdn, 'c': '', 'o': '', 'ou': ''}
+    if has_csr:
         try:
             csr = load_csr(csr_file)
             for attr in csr.subject:
@@ -325,91 +467,84 @@ def manage_cert(fqdn):
                 elif attr.oid == NameOID.ORGANIZATIONAL_UNIT_NAME:
                     csr_details['ou'] = attr.value
         except Exception:
-            pass # Could not parse CSR, default to empty
+            pass
 
-    return render_template('manage.html', fqdn=fqdn, ext_content=ext_content, has_crt=has_crt, has_p12=has_p12, csr=csr_details)
+    cert_type = get_cert_type(cert_dir)
+    cert_details = parse_cert_details(crt_file) if has_crt else None
+
+    return render_template('manage.html',
+                           fqdn=fqdn,
+                           ext_content=ext_content,
+                           has_crt=has_crt,
+                           has_p12=has_p12,
+                           has_key=has_key,
+                           has_csr=has_csr,
+                           csr=csr_details,
+                           cert_type=cert_type,
+                           cert_details=cert_details)
 
 @app.route('/cert/update_details/<fqdn>', methods=['POST'])
 def update_details(fqdn):
-    # Retrieve form data
     new_cn = request.form.get('cn', '').strip()
     c = request.form.get('c', '').strip()
     o = request.form.get('o', '').strip()
     ou = request.form.get('ou', '').strip()
-    
+
     if not new_cn:
         flash("Common Name (FQDN) is required.", "error")
         return redirect(url_for('manage_cert', fqdn=fqdn))
 
-    cert_path = os.path.join(CERT_DIR, fqdn)
-    key_path = os.path.join(cert_path, f"{fqdn}.key")
-    
-    # Load existing private key
+    cert_dir = os.path.join(CERT_DIR, fqdn)
+    key_path = os.path.join(cert_dir, f"{fqdn}.key")
+
     if not os.path.exists(key_path):
-         flash("Private key not found. Cannot regenerate CSR.", "error")
-         return redirect(url_for('manage_cert', fqdn=fqdn))
-         
+        flash("Private key not found. Cannot regenerate CSR.", "error")
+        return redirect(url_for('manage_cert', fqdn=fqdn))
+
     try:
         private_key = load_key(key_path)
-        
-        # Build new Subject
         subject = x509.Name([
             x509.NameAttribute(NameOID.COUNTRY_NAME, c),
             x509.NameAttribute(NameOID.ORGANIZATION_NAME, o),
             x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, ou),
             x509.NameAttribute(NameOID.COMMON_NAME, new_cn),
         ])
-
-        # Generate new CSR
         csr = (
             x509.CertificateSigningRequestBuilder()
             .subject_name(subject)
             .sign(private_key, hashes.SHA256())
         )
-        
-        # Logic for handling Name Change vs Same Name
+
         if new_cn == fqdn:
-            # Simple overwrite
-            csr_path = os.path.join(cert_path, f"{fqdn}.csr")
-            with open(csr_path, "wb") as f:
+            with open(os.path.join(cert_dir, f"{fqdn}.csr"), "wb") as f:
                 f.write(csr.public_bytes(serialization.Encoding.PEM))
             flash("Certificate details updated (CSR regenerated).", "success")
             return redirect(url_for('manage_cert', fqdn=fqdn))
-        else:
-            # Rename required
-            new_cert_path = os.path.join(CERT_DIR, new_cn)
-            if os.path.exists(new_cert_path):
-                flash(f"Destination {new_cn} already exists.", "error")
-                return redirect(url_for('manage_cert', fqdn=fqdn))
-            
-            # 1. Overwrite CSR in current folder first (simplifies move)
-            old_csr_path = os.path.join(cert_path, f"{fqdn}.csr")
-            with open(old_csr_path, "wb") as f:
-                f.write(csr.public_bytes(serialization.Encoding.PEM))
-                
-            # 2. Update v3.ext if it contains the OLD name
-            ext_path = os.path.join(cert_path, f"{fqdn}.v3.ext")
-            if os.path.exists(ext_path):
-                with open(ext_path, 'r') as f:
-                    content = f.read()
-                # Simple string replace for the mandatory field
-                content = content.replace(f"DNS.1 = {fqdn}", f"DNS.1 = {new_cn}")
-                with open(ext_path, 'w') as f:
-                    f.write(content)
-            
-            # 3. Rename internal files
-            # Iterate through known extensions to rename: key, csr, crt, v3.ext, p12
-            for ext in ['.key', '.csr', '.crt', '.v3.ext', '.p12']:
-                old_f = os.path.join(cert_path, f"{fqdn}{ext}")
-                new_f = os.path.join(cert_path, f"{new_cn}{ext}")
-                if os.path.exists(old_f):
-                    os.rename(old_f, new_f)
-            
-            # 4. Rename Directory
-            os.rename(cert_path, new_cert_path)
-            
-            flash(f"Details updated and renamed to {new_cn}.", "success")
-            return redirect(url_for('manage_cert', fqdn=new_cn))
+
+        new_cert_dir = os.path.join(CERT_DIR, new_cn)
+        if os.path.exists(new_cert_dir):
+            flash(f"Destination {new_cn} already exists.", "error")
+            return redirect(url_for('manage_cert', fqdn=fqdn))
+
+        with open(os.path.join(cert_dir, f"{fqdn}.csr"), "wb") as f:
+            f.write(csr.public_bytes(serialization.Encoding.PEM))
+
+        ext_path = os.path.join(cert_dir, f"{fqdn}.v3.ext")
+        if os.path.exists(ext_path):
+            with open(ext_path, 'r') as f:
+                content = f.read()
+            content = content.replace(f"DNS.1 = {fqdn}", f"DNS.1 = {new_cn}")
+            with open(ext_path, 'w') as f:
+                f.write(content)
+
+        for ext in ['.key', '.csr', '.crt', '.v3.ext', '.p12']:
+            old_f = os.path.join(cert_dir, f"{fqdn}{ext}")
+            if os.path.exists(old_f):
+                os.rename(old_f, os.path.join(cert_dir, f"{new_cn}{ext}"))
+
+        os.rename(cert_dir, new_cert_dir)
+        flash(f"Details updated and renamed to {new_cn}.", "success")
+        return redirect(url_for('manage_cert', fqdn=new_cn))
 
     except Exception as e:
         flash(f"Error updating details: {str(e)}", "error")
@@ -427,12 +562,13 @@ def update_ext(fqdn):
 @app.route('/cert/sign_root/<fqdn>', methods=['POST'])
 def sign_root(fqdn):
     password = request.form.get('password')
+    days = int(request.form.get('days', '365'))
 
-    cert_path = os.path.join(CERT_DIR, fqdn)
-    csr_path = os.path.join(cert_path, f"{fqdn}.csr")
-    crt_path = os.path.join(cert_path, f"{fqdn}.crt")
-    ext_path = os.path.join(cert_path, f"{fqdn}.v3.ext")
-    
+    cert_dir = os.path.join(CERT_DIR, fqdn)
+    csr_path = os.path.join(cert_dir, f"{fqdn}.csr")
+    crt_path = os.path.join(cert_dir, f"{fqdn}.crt")
+    ext_path = os.path.join(cert_dir, f"{fqdn}.v3.ext")
+
     ca_crt_path = os.path.join(ROOT_DIR, f"{ROOT_CA_NAME}.crt")
     ca_key_path = os.path.join(ROOT_DIR, f"{ROOT_CA_NAME}.key")
 
@@ -440,137 +576,95 @@ def sign_root(fqdn):
         csr = load_csr(csr_path)
         ca_cert = load_cert(ca_crt_path)
         ca_key = load_key(ca_key_path, password=password)
+        cert_type = get_cert_type(cert_dir)
 
-        builder = x509.CertificateBuilder()
-        builder = builder.subject_name(csr.subject)
-        builder = builder.issuer_name(ca_cert.subject)
-        builder = builder.public_key(csr.public_key())
-        builder = builder.serial_number(x509.random_serial_number())
-        builder = builder.not_valid_before(datetime.datetime.now(datetime.timezone.utc))
-        builder = builder.not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365))
-
-        builder = builder.add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
-        builder = builder.add_extension(x509.KeyUsage(
-            digital_signature=True, content_commitment=False, key_encipherment=True,
-            data_encipherment=False, key_agreement=False, key_cert_sign=False,
-            crl_sign=False, encipher_only=False, decipher_only=False
-        ), critical=True)
-        builder = builder.add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]), critical=False)
-        
-        builder = builder.add_extension(
-            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()), 
-            critical=False
+        cert = _build_cert(
+            csr, ca_cert.subject, ca_key.public_key(), ca_key, days, cert_type, ext_path
         )
-        builder = builder.add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(csr.public_key()), 
-            critical=False
-        )
-
-        if os.path.exists(ext_path):
-            with open(ext_path, 'r') as f:
-                content = f.read()
-            sans = get_sans_from_ext_content(content)
-            if sans:
-                builder = builder.add_extension(x509.SubjectAlternativeName(sans), critical=False)
-
-        cert = builder.sign(ca_key, hashes.SHA256())
         save_cert(cert, crt_path)
-        
         flash('Signed by Root CA successfully.', 'success')
 
     except ValueError:
-        flash('Incorrect Password for Root CA Key.', 'error')
+        flash('Incorrect password for Root CA key.', 'error')
     except Exception as e:
         flash(f'Signing failed: {str(e)}', 'error')
-    
+
     return redirect(url_for('manage_cert', fqdn=fqdn))
 
-@app.route('/cert/sign_self/<fqdn>')
+@app.route('/cert/sign_self/<fqdn>', methods=['POST'])
 def sign_self(fqdn):
-    cert_path = os.path.join(CERT_DIR, fqdn)
-    csr_path = os.path.join(cert_path, f"{fqdn}.csr")
-    key_path = os.path.join(cert_path, f"{fqdn}.key")
-    crt_path = os.path.join(cert_path, f"{fqdn}.crt")
-    ext_path = os.path.join(cert_path, f"{fqdn}.v3.ext")
+    days = int(request.form.get('days', '365'))
+    cert_dir = os.path.join(CERT_DIR, fqdn)
+    csr_path = os.path.join(cert_dir, f"{fqdn}.csr")
+    key_path = os.path.join(cert_dir, f"{fqdn}.key")
+    crt_path = os.path.join(cert_dir, f"{fqdn}.crt")
+    ext_path = os.path.join(cert_dir, f"{fqdn}.v3.ext")
 
     try:
         csr = load_csr(csr_path)
         private_key = load_key(key_path)
+        cert_type = get_cert_type(cert_dir)
 
-        builder = x509.CertificateBuilder()
-        builder = builder.subject_name(csr.subject)
-        builder = builder.issuer_name(csr.subject) # Self signed
-        builder = builder.public_key(csr.public_key())
-        builder = builder.serial_number(x509.random_serial_number())
-        builder = builder.not_valid_before(datetime.datetime.now(datetime.timezone.utc))
-        builder = builder.not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365))
-
-        builder = builder.add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
-        builder = builder.add_extension(x509.KeyUsage(
-            digital_signature=True, content_commitment=False, key_encipherment=True,
-            data_encipherment=False, key_agreement=False, key_cert_sign=False,
-            crl_sign=False, encipher_only=False, decipher_only=False
-        ), critical=True)
-        builder = builder.add_extension(x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]), critical=False)
-        builder = builder.add_extension(
-            x509.SubjectKeyIdentifier.from_public_key(csr.public_key()), 
-            critical=False
+        cert = _build_cert(
+            csr, csr.subject, private_key.public_key(), private_key, days, cert_type, ext_path
         )
-
-        if os.path.exists(ext_path):
-            with open(ext_path, 'r') as f:
-                content = f.read()
-            sans = get_sans_from_ext_content(content)
-            if sans:
-                builder = builder.add_extension(x509.SubjectAlternativeName(sans), critical=False)
-
-        cert = builder.sign(private_key, hashes.SHA256())
         save_cert(cert, crt_path)
-        
         flash('Self-signed successfully.', 'success')
+
     except Exception as e:
         flash(f'Signing failed: {str(e)}', 'error')
-    
+
     return redirect(url_for('manage_cert', fqdn=fqdn))
 
 @app.route('/cert/create_p12/<fqdn>', methods=['POST'])
 def create_p12(fqdn):
     password = request.form.get('password', '')
-    cert_path = os.path.join(CERT_DIR, fqdn)
-    key_path = os.path.join(cert_path, f"{fqdn}.key")
-    crt_path = os.path.join(cert_path, f"{fqdn}.crt")
-    p12_path = os.path.join(cert_path, f"{fqdn}.p12")
+    cert_dir = os.path.join(CERT_DIR, fqdn)
+    key_path = os.path.join(cert_dir, f"{fqdn}.key")
+    crt_path = os.path.join(cert_dir, f"{fqdn}.crt")
+    p12_path = os.path.join(cert_dir, f"{fqdn}.p12")
 
     try:
         private_key = load_key(key_path)
         cert = load_cert(crt_path)
 
+        ca_certs = None
+        ca_crt_path = os.path.join(ROOT_DIR, f"{ROOT_CA_NAME}.crt")
+        if os.path.exists(ca_crt_path):
+            try:
+                ca_cert = load_cert(ca_crt_path)
+                if cert.issuer == ca_cert.subject:
+                    ca_certs = [ca_cert]
+            except Exception:
+                pass
+
         p12 = pkcs12.serialize_key_and_certificates(
             name=fqdn.encode('utf-8'),
             key=private_key,
             cert=cert,
-            cas=None,
-            encryption_algorithm=serialization.BestAvailableEncryption(password.encode('utf-8'))
+            cas=ca_certs,
+            encryption_algorithm=serialization.BestAvailableEncryption(password.encode('utf-8')),
         )
-
         with open(p12_path, "wb") as f:
             f.write(p12)
 
-        flash('PF12 container created successfully.', 'success')
+        flash('P12 container created successfully.', 'success')
+
     except Exception as e:
-        flash(f'PF12 creation failed: {str(e)}', 'error')
-        
+        flash(f'P12 creation failed: {str(e)}', 'error')
+
     return redirect(url_for('manage_cert', fqdn=fqdn))
 
-@app.route('/cert/delete/<fqdn>')
+@app.route('/cert/delete/<fqdn>', methods=['POST'])
 def delete_cert(fqdn):
-    cert_path = os.path.join(CERT_DIR, fqdn)
+    cert_dir = os.path.join(CERT_DIR, fqdn)
     try:
-        shutil.rmtree(cert_path)
+        shutil.rmtree(cert_dir)
         flash(f'Certificate {fqdn} deleted.', 'success')
     except Exception as e:
         flash(f'Error deleting: {str(e)}', 'error')
     return redirect(url_for('index'))
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)

--- a/templates/create.html
+++ b/templates/create.html
@@ -2,16 +2,41 @@
 {% block content %}
 <div class="max-w-2xl mx-auto bg-white dark:bg-s1-800 rounded-lg shadow p-8 border dark:border-s1-700">
     <h1 class="text-2xl font-bold mb-6">Create New Certificate Request</h1>
-    
+
     <form method="POST" class="space-y-4">
+
+        <!-- Certificate Type -->
         <div>
-            <label class="block text-sm font-medium mb-1">FQDN (Common Name)</label>
-            <input type="text" name="fqdn" placeholder="www.example.com" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" required>
+            <label class="block text-sm font-medium mb-2">Certificate Type</label>
+            <div class="grid grid-cols-2 gap-3">
+                <label class="relative flex items-start p-3 rounded border dark:border-s1-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-s1-700 transition has-[:checked]:border-s1-500 has-[:checked]:bg-s1-50 dark:has-[:checked]:bg-s1-900">
+                    <input type="radio" name="cert_type" value="server" checked class="mt-0.5 mr-3 accent-purple-600">
+                    <div>
+                        <span class="font-medium text-sm">Server</span>
+                        <p class="text-xs text-gray-500 mt-0.5">TLS for websites and services (serverAuth)</p>
+                    </div>
+                </label>
+                <label class="relative flex items-start p-3 rounded border dark:border-s1-700 cursor-pointer hover:bg-gray-50 dark:hover:bg-s1-700 transition has-[:checked]:border-s1-500 has-[:checked]:bg-s1-50 dark:has-[:checked]:bg-s1-900">
+                    <input type="radio" name="cert_type" value="client" class="mt-0.5 mr-3 accent-purple-600">
+                    <div>
+                        <span class="font-medium text-sm">Client</span>
+                        <p class="text-xs text-gray-500 mt-0.5">mTLS client authentication (clientAuth)</p>
+                    </div>
+                </label>
+            </div>
         </div>
+
+        <!-- FQDN -->
+        <div>
+            <label class="block text-sm font-medium mb-1">FQDN / Common Name</label>
+            <input type="text" name="fqdn" placeholder="www.example.com  or  user@example.com" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" required>
+            <p class="text-xs text-gray-500 mt-1">For client certs this is typically an email address or username.</p>
+        </div>
+
         <div class="grid grid-cols-2 gap-4">
             <div>
                 <label class="block text-sm font-medium mb-1">Country</label>
-                <input type="text" name="c" value="NL" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white">
+                <input type="text" name="c" value="NL" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="2">
             </div>
             <div>
                 <label class="block text-sm font-medium mb-1">Organization</label>

--- a/templates/create_root.html
+++ b/templates/create_root.html
@@ -24,7 +24,7 @@
         </div>
         <div>
             <label class="block text-sm font-medium mb-1">Validaty in days (default 10 years)</label>
-            <input type="text" name="days" value="3650" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="2" required>
+            <input type="text" name="days" value="3650" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="5" required>
         </div>
         <div>
             <label class="block text-sm font-medium mb-1">Contact Email address (optional)</label>

--- a/templates/create_root.html
+++ b/templates/create_root.html
@@ -2,49 +2,54 @@
 {% block content %}
 <div class="max-w-2xl mx-auto bg-white dark:bg-s1-800 rounded-lg shadow p-8 border dark:border-s1-700">
     <h1 class="text-2xl font-bold mb-6">Create Root Certificate Authority</h1>
-    
+
     <div class="mb-6 p-4 bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-200 rounded border border-yellow-200 dark:border-yellow-800 text-sm">
         <p class="font-bold">Warning:</p>
         <p>Creating a new Root CA will overwrite any existing one. All certificates signed by the previous Root CA will become invalid.</p>
     </div>
-    
+
     <form method="POST" class="space-y-4">
         <div>
             <label class="block text-sm font-medium mb-1">Root CA Common Name (required)</label>
-            <input type="text" name="cn" placeholder="My Internal Root CA" value="My Internal Root CA" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" required>
+            <input type="text" name="cn" placeholder="My Internal Root CA"
+                   value="{{ prefill_cn or 'My Internal Root CA' }}"
+                   class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" required>
             <p class="text-xs text-gray-500 mt-1">This is the name that will appear in your trusted store.</p>
         </div>
         <div>
-            <label class="block text-sm font-medium mb-1">Country in 2 Letter Code (required)</label>
+            <label class="block text-sm font-medium mb-1">Country (2-letter code, required)</label>
             <input type="text" name="c" value="NL" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="2" required>
         </div>
         <div>
-            <label class="block text-xs uppercase font-bold text-gray-500 mb-1">Password</label>
-            <input type="password" name="password" class="w-full p-2 mb-6 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white focus:ring-2 focus:ring-s1-500 outline-none" autofocus>
+            <label class="block text-xs uppercase font-bold text-gray-500 mb-1">Password (optional)</label>
+            <input type="password" name="password" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white focus:ring-2 focus:ring-s1-500 outline-none" autofocus>
+            <p class="text-xs text-gray-500 mt-1">If set, this password will be required when signing certificates.</p>
         </div>
         <div>
-            <label class="block text-sm font-medium mb-1">Validaty in days (default 10 years)</label>
-            <input type="text" name="days" value="3650" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="5" required>
-        </div>
-        <div>
-            <label class="block text-sm font-medium mb-1">Contact Email address (optional)</label>
-            <input type="text" name="email" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="20">
+            <label class="block text-sm font-medium mb-1">Validity in days (default 10 years)</label>
+            <input type="number" name="days" value="3650" min="1" max="36500" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" required>
         </div>
         <div>
             <label class="block text-sm font-medium mb-1">Organization (optional)</label>
-            <input type="text" name="org" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="25">
+            <input type="text" name="org" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="64">
         </div>
         <div>
             <label class="block text-sm font-medium mb-1">Organizational Unit (OU) (optional)</label>
-            <input type="text" name="org_unit" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="15">
+            <input type="text" name="org_unit" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="64">
+        </div>
+        <div class="grid grid-cols-2 gap-4">
+            <div>
+                <label class="block text-sm font-medium mb-1">State/Province (optional)</label>
+                <input type="text" name="st" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white">
+            </div>
+            <div>
+                <label class="block text-sm font-medium mb-1">City/Town (optional)</label>
+                <input type="text" name="city" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white">
+            </div>
         </div>
         <div>
-            <label class="block text-sm font-medium mb-1">State/Province (optional)</label>
-            <input type="text" name="st" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="10">
-        </div>
-        <div>
-            <label class="block text-sm font-medium mb-1">City or Town Name (optional)</label>
-            <input type="text" name="city" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white" maxlength="15">
+            <label class="block text-sm font-medium mb-1">Contact Email (optional)</label>
+            <input type="email" name="email" value="" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white">
         </div>
         <div class="pt-4 flex justify-end space-x-3">
             <a href="/" class="px-4 py-2 rounded border dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-s1-700">Cancel</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,21 +2,38 @@
 
 {% block content %}
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-    
+
     <div class="md:col-span-1 space-y-6">
+
+        <!-- Root CA Status -->
         <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
             <h2 class="text-lg font-bold mb-4 text-s1-500 dark:text-s1-400">Root CA Status</h2>
             {% if root_exists %}
-                <div class="flex items-center text-green-600 dark:text-green-400 mb-4">
+                <div class="flex items-center text-green-600 dark:text-green-400 mb-3">
                     <span class="text-2xl mr-2">✓</span> Active
                 </div>
-                <p class="text-sm text-gray-500 mb-4">Root {{ root_filename }} is ready to sign.</p>
-                
-                <a href="{{ url_for('download_root') }}" class="block text-center w-full bg-green-600 hover:bg-green-500 text-white py-2 rounded mb-4 transition">
+
+                {% if root_info %}
+                <dl class="text-sm mb-4 space-y-1">
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">CN</dt>
+                        <dd class="font-medium truncate ml-2">{{ root_info.cn }}</dd>
+                    </div>
+                    <div class="flex justify-between">
+                        <dt class="text-gray-500">Expires</dt>
+                        <dd class="font-mono {% if root_info.days_left < 90 %}text-yellow-500{% else %}text-green-600 dark:text-green-400{% endif %}">
+                            {{ root_info.not_after }}
+                            <span class="text-xs">({{ root_info.days_left }}d)</span>
+                        </dd>
+                    </div>
+                </dl>
+                {% endif %}
+
+                <a href="{{ url_for('download_root') }}" class="block text-center w-full bg-green-600 hover:bg-green-500 text-white py-2 rounded mb-4 transition text-sm">
                     Download {{ root_filename }}
                 </a>
 
-                <details class="mt-4">
+                <details class="mt-2">
                     <summary class="text-xs text-gray-500 cursor-pointer hover:text-gray-700">Advanced: Recreate Root CA</summary>
                     <div class="mt-2 p-3 bg-red-50 dark:bg-red-900/20 rounded border border-red-100 dark:border-red-900">
                         <p class="text-xs text-red-600 mb-2">Warning: Recreating the Root CA will invalidate all previously signed certificates.</p>
@@ -27,7 +44,7 @@
                     </div>
                 </details>
             {% else %}
-                <p class="text-sm mb-4">No Root CA found.</p>
+                <p class="text-sm mb-4 text-gray-500">No Root CA found. Create one before signing certificates.</p>
                 <form action="/cert/create_root" method="GET">
                     <input type="text" name="cn" placeholder="Common Name" class="w-full mb-2 p-2 rounded border dark:bg-s1-900 dark:border-s1-700" required>
                     <button type="submit" class="w-full bg-s1-500 hover:bg-s1-400 text-white py-2 rounded transition">Create Root CA</button>
@@ -35,53 +52,80 @@
             {% endif %}
         </div>
 
+        <!-- New Certificate -->
         <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
             <h2 class="text-lg font-bold mb-4 text-s1-500 dark:text-s1-400">New Certificate</h2>
-            <p class="text-sm mb-4 text-gray-500">Generate a new Private Key and CSR.</p>
+            <p class="text-sm mb-4 text-gray-500">Generate a new key and CSR for a server or client certificate.</p>
             <a href="/cert/create" class="block text-center w-full border border-s1-500 text-s1-500 dark:text-s1-400 hover:bg-s1-500 hover:text-white py-2 rounded transition">Start Wizard</a>
         </div>
     </div>
 
+    <!-- Certificate Table -->
     <div class="md:col-span-2">
         <div class="bg-white dark:bg-s1-800 rounded-lg shadow overflow-hidden border dark:border-s1-700">
             <div class="px-6 py-4 border-b dark:border-s1-700 flex justify-between items-center">
                 <h2 class="text-lg font-bold">Managed Certificates</h2>
                 <span class="bg-s1-700 text-white px-2 py-1 rounded text-xs">{{ certs|length }} found</span>
             </div>
-            <table class="w-full text-left">
-                <thead class="bg-gray-50 dark:bg-s1-900">
-                    <tr>
-                        <th class="px-6 py-3 text-xs font-medium uppercase tracking-wider">FQDN</th>
-                        <th class="px-6 py-3 text-xs font-medium uppercase tracking-wider">Status</th>
-                        <th class="px-6 py-3 text-xs font-medium uppercase tracking-wider">Actions</th>
-                    </tr>
-                </thead>
-                <tbody class="divide-y divide-gray-200 dark:divide-s1-700">
-                    {% for cert in certs %}
-                    <tr class="hover:bg-gray-50 dark:hover:bg-s1-700 transition">
-                        <td class="px-6 py-4 font-medium">{{ cert.fqdn }}</td>
-                        <td class="px-6 py-4">
-                            {% if cert.status == 'green' %}
-                                <span class="px-2 py-1 text-xs rounded bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">Trusted (Root)</span>
-                            {% elif cert.status == 'blue' %}
-                                <span class="px-2 py-1 text-xs rounded bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">Self-Signed</span>
-                            {% elif cert.status == 'red' %}
-                                <span class="px-2 py-1 text-xs rounded bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">Unknown/Mismatch</span>
-                            {% else %}
-                                <span class="px-2 py-1 text-xs rounded bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">Pending</span>
-                            {% endif %}
-                        </td>
-                        <td class="px-6 py-4">
-                            <a href="/cert/manage/{{ cert.fqdn }}" class="text-s1-500 hover:text-s1-400 font-semibold mr-4">Manage</a>
-                        </td>
-                    </tr>
-                    {% else %}
-                    <tr>
-                        <td colspan="3" class="px-6 py-8 text-center text-gray-500">No certificates found. Create one to get started.</td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            <div class="overflow-x-auto">
+                <table class="w-full text-left">
+                    <thead class="bg-gray-50 dark:bg-s1-900">
+                        <tr>
+                            <th class="px-4 py-3 text-xs font-medium uppercase tracking-wider">FQDN</th>
+                            <th class="px-4 py-3 text-xs font-medium uppercase tracking-wider">Type</th>
+                            <th class="px-4 py-3 text-xs font-medium uppercase tracking-wider">Status</th>
+                            <th class="px-4 py-3 text-xs font-medium uppercase tracking-wider">Expires</th>
+                            <th class="px-4 py-3 text-xs font-medium uppercase tracking-wider">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-gray-200 dark:divide-s1-700">
+                        {% for cert in certs %}
+                        <tr class="hover:bg-gray-50 dark:hover:bg-s1-700 transition">
+                            <td class="px-4 py-4 font-medium text-sm">{{ cert.fqdn }}</td>
+                            <td class="px-4 py-4">
+                                {% if cert.cert_type == 'client' %}
+                                    <span class="px-2 py-0.5 text-xs rounded bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">Client</span>
+                                {% else %}
+                                    <span class="px-2 py-0.5 text-xs rounded bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">Server</span>
+                                {% endif %}
+                            </td>
+                            <td class="px-4 py-4">
+                                {% if cert.status == 'green' %}
+                                    <span class="px-2 py-1 text-xs rounded bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">Trusted</span>
+                                {% elif cert.status == 'blue' %}
+                                    <span class="px-2 py-1 text-xs rounded bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">Self-Signed</span>
+                                {% elif cert.status == 'red' %}
+                                    <span class="px-2 py-1 text-xs rounded bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">Unknown</span>
+                                {% elif cert.status == 'error' %}
+                                    <span class="px-2 py-1 text-xs rounded bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200">Error</span>
+                                {% else %}
+                                    <span class="px-2 py-1 text-xs rounded bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">Pending</span>
+                                {% endif %}
+                            </td>
+                            <td class="px-4 py-4 text-sm">
+                                {% if cert.not_after %}
+                                    <span class="font-mono {% if cert.days_left is not none and cert.days_left < 0 %}text-red-500{% elif cert.days_left is not none and cert.days_left < 30 %}text-yellow-500{% endif %}">
+                                        {{ cert.not_after }}
+                                    </span>
+                                    {% if cert.days_left is not none %}
+                                        <span class="text-xs text-gray-400 block">{{ cert.days_left }}d left</span>
+                                    {% endif %}
+                                {% else %}
+                                    <span class="text-gray-400">—</span>
+                                {% endif %}
+                            </td>
+                            <td class="px-4 py-4">
+                                <a href="/cert/manage/{{ cert.fqdn }}" class="text-s1-500 hover:text-s1-400 font-semibold text-sm">Manage</a>
+                            </td>
+                        </tr>
+                        {% else %}
+                        <tr>
+                            <td colspan="5" class="px-6 py-8 text-center text-gray-500">No certificates found. Create one to get started.</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/manage.html
+++ b/templates/manage.html
@@ -1,19 +1,82 @@
 {% extends "layout.html" %}
 {% block content %}
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-    
+
+    <!-- Left: info, details, extensions -->
     <div class="lg:col-span-2 space-y-6">
+
+        <!-- Header -->
         <div class="flex justify-between items-center pb-4 border-b dark:border-s1-700">
-            <h1 class="text-2xl font-bold">{{ fqdn }}</h1>
-            <a href="/cert/delete/{{ fqdn }}" onclick="return confirm('Are you sure? This deletes the entire directory for this certificate.')" class="px-4 py-2 bg-red-600 hover:bg-red-500 text-white text-sm font-bold rounded shadow transition">
-                Delete Certificate
-            </a>
+            <div>
+                <h1 class="text-2xl font-bold">{{ fqdn }}</h1>
+                <div class="mt-1">
+                    {% if cert_type == 'client' %}
+                        <span class="px-2 py-0.5 text-xs rounded bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">Client Certificate</span>
+                    {% else %}
+                        <span class="px-2 py-0.5 text-xs rounded bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">Server Certificate</span>
+                    {% endif %}
+                </div>
+            </div>
+            <form action="/cert/delete/{{ fqdn }}" method="POST"
+                  onsubmit="return confirm('Are you sure? This permanently deletes all files for {{ fqdn }}.')">
+                <button type="submit" class="px-4 py-2 bg-red-600 hover:bg-red-500 text-white text-sm font-bold rounded shadow transition">
+                    Delete Certificate
+                </button>
+            </form>
         </div>
 
+        <!-- Parsed Certificate Info (when signed) -->
+        {% if cert_details %}
         <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
-            <h3 class="text-lg font-bold mb-4">Certificate Details</h3>
-            <p class="text-xs text-gray-500 mb-4">Modify the parameters below to regenerate the CSR. <br><span class="text-red-500">Note: Changing the FQDN will rename the certificate directory and files.</span></p>
-            
+            <h3 class="text-lg font-bold mb-4">Certificate Info</h3>
+            <dl class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+                <div>
+                    <dt class="text-xs uppercase font-bold text-gray-500 mb-0.5">Subject CN</dt>
+                    <dd class="font-mono">{{ cert_details.subject_cn or '—' }}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs uppercase font-bold text-gray-500 mb-0.5">Issuer CN</dt>
+                    <dd class="font-mono">{{ cert_details.issuer_cn or '—' }}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs uppercase font-bold text-gray-500 mb-0.5">Valid From</dt>
+                    <dd class="font-mono text-xs">{{ cert_details.not_before }}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs uppercase font-bold text-gray-500 mb-0.5">Expires</dt>
+                    <dd class="font-mono text-xs {% if cert_details.days_left < 0 %}text-red-500{% elif cert_details.days_left < 30 %}text-yellow-500{% else %}text-green-600 dark:text-green-400{% endif %}">
+                        {{ cert_details.not_after }}
+                        {% if cert_details.days_left < 0 %}
+                            <span class="ml-1">(expired)</span>
+                        {% else %}
+                            <span class="ml-1">({{ cert_details.days_left }}d left)</span>
+                        {% endif %}
+                    </dd>
+                </div>
+                <div>
+                    <dt class="text-xs uppercase font-bold text-gray-500 mb-0.5">Serial</dt>
+                    <dd class="font-mono text-xs break-all">{{ cert_details.serial }}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs uppercase font-bold text-gray-500 mb-0.5">Extended Key Usage</dt>
+                    <dd class="text-xs">{{ cert_details.eku | join(', ') or '—' }}</dd>
+                </div>
+                {% if cert_details.sans %}
+                <div class="md:col-span-2">
+                    <dt class="text-xs uppercase font-bold text-gray-500 mb-0.5">Subject Alt Names</dt>
+                    <dd class="font-mono text-xs">{{ cert_details.sans | join('  ·  ') }}</dd>
+                </div>
+                {% endif %}
+            </dl>
+        </div>
+        {% endif %}
+
+        <!-- CSR Subject Details -->
+        <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
+            <h3 class="text-lg font-bold mb-4">Certificate Details (CSR)</h3>
+            <p class="text-xs text-gray-500 mb-4">Modify the parameters below to regenerate the CSR.<br>
+                <span class="text-red-500">Note: Changing the FQDN will rename the certificate directory and files.</span>
+            </p>
             <form action="/cert/update_details/{{ fqdn }}" method="POST" class="space-y-4">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
@@ -33,17 +96,18 @@
                         <input type="text" name="ou" value="{{ csr.ou }}" class="w-full p-2 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white">
                     </div>
                 </div>
-                <div class="text-right mt-2">
-                    <button type="submit" class="px-3 py-1 bg-s1-500 hover:bg-s1-400 text-white text-sm rounded transition">Update Details & CSR</button>
+                <div class="text-right">
+                    <button type="submit" class="px-3 py-1 bg-s1-500 hover:bg-s1-400 text-white text-sm rounded transition">Update Details & Regenerate CSR</button>
                 </div>
             </form>
         </div>
 
+        <!-- Extension File -->
         <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
             <h3 class="text-lg font-bold mb-2">Extension File (v3.ext)</h3>
-            <p class="text-xs text-gray-500 mb-2">Edit this to add Subject Alternative Names (SANs) before signing.</p>
+            <p class="text-xs text-gray-500 mb-2">Edit SANs and key usage before signing. Re-sign after saving changes.</p>
             <form action="/cert/update_ext/{{ fqdn }}" method="POST">
-                <textarea name="ext_content" rows="8" class="w-full font-mono text-sm p-3 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-gray-300">{{ ext_content }}</textarea>
+                <textarea name="ext_content" rows="9" class="w-full font-mono text-sm p-3 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-gray-300">{{ ext_content }}</textarea>
                 <div class="mt-2 text-right">
                     <button type="submit" class="px-3 py-1 bg-gray-600 hover:bg-gray-500 text-white text-sm rounded">Save Extensions</button>
                 </div>
@@ -51,60 +115,135 @@
         </div>
     </div>
 
+    <!-- Right: signing, downloads, export -->
     <div class="space-y-6">
+
+        <!-- Signing Actions -->
         <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
-            <h3 class="text-lg font-bold mb-4">Signing Actions</h3>
-            
+            <h3 class="text-lg font-bold mb-4">Signing</h3>
+
             {% if has_crt %}
-                <div class="bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 p-3 rounded mb-4 text-center">
-                    Certificate Signed (.crt exists)
+                <div class="bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400 p-3 rounded mb-3 text-center text-sm font-medium">
+                    Certificate signed
                 </div>
-                <p class="text-xs text-center text-gray-500 mb-4">You can re-sign if you changed extensions.</p>
+                <p class="text-xs text-center text-gray-500 mb-4">Re-sign to apply updated extensions or to renew.</p>
             {% else %}
-                <div class="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 p-3 rounded mb-4 text-center">
+                <div class="bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 p-3 rounded mb-4 text-center text-sm font-medium">
                     Pending Signature
                 </div>
             {% endif %}
 
             <div class="space-y-3">
-                <button onclick="document.getElementById('passwordModal').classList.remove('hidden')" class="block w-full text-center py-2 bg-s1-500 hover:bg-s1-400 text-white rounded shadow transition">
-                    Sign with Root CA
+                <button onclick="document.getElementById('passwordModal').classList.remove('hidden')"
+                        class="block w-full text-center py-2 bg-s1-500 hover:bg-s1-400 text-white rounded shadow transition text-sm">
+                    {% if has_crt %}Re-sign{% else %}Sign{% endif %} with Root CA
                 </button>
-                
-                <a href="/cert/sign_self/{{ fqdn }}" class="block w-full text-center py-2 border border-s1-500 text-s1-500 dark:text-s1-400 hover:bg-s1-500 hover:text-white rounded transition">Self-Sign</a>
+
+                <form action="/cert/sign_self/{{ fqdn }}" method="POST"
+                      {% if has_crt %}onsubmit="return confirm('This will replace the existing certificate. Continue?')"{% endif %}>
+                    <div class="flex items-center space-x-2 mb-2">
+                        <input type="number" name="days" value="365" min="1" max="3650"
+                               class="w-20 p-1 text-sm rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white text-center">
+                        <span class="text-xs text-gray-500">days validity</span>
+                    </div>
+                    <button type="submit"
+                            class="block w-full text-center py-2 border border-s1-500 text-s1-500 dark:text-s1-400 hover:bg-s1-500 hover:text-white rounded transition text-sm">
+                        {% if has_crt %}Re-{% endif %}Self-Sign
+                    </button>
+                </form>
             </div>
         </div>
 
+        <!-- Downloads -->
         <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
-            <h3 class="text-lg font-bold mb-4">Export .pem/.pf12</h3>
+            <h3 class="text-lg font-bold mb-4">Downloads</h3>
+            <div class="space-y-2">
+                {% if has_crt %}
+                <a href="/cert/download/{{ fqdn }}/crt"
+                   class="flex items-center justify-between w-full px-3 py-2 rounded border dark:border-s1-700 hover:bg-gray-50 dark:hover:bg-s1-700 transition text-sm">
+                    <span class="font-mono">{{ fqdn }}.crt</span>
+                    <span class="text-xs text-gray-500">Certificate</span>
+                </a>
+                {% endif %}
+                {% if has_csr %}
+                <a href="/cert/download/{{ fqdn }}/csr"
+                   class="flex items-center justify-between w-full px-3 py-2 rounded border dark:border-s1-700 hover:bg-gray-50 dark:hover:bg-s1-700 transition text-sm">
+                    <span class="font-mono">{{ fqdn }}.csr</span>
+                    <span class="text-xs text-gray-500">CSR</span>
+                </a>
+                {% endif %}
+                {% if has_key %}
+                <a href="/cert/download/{{ fqdn }}/key"
+                   class="flex items-center justify-between w-full px-3 py-2 rounded border dark:border-s1-700 hover:bg-gray-50 dark:hover:bg-s1-700 transition text-sm">
+                    <span class="font-mono">{{ fqdn }}.key</span>
+                    <span class="text-xs text-orange-500">Private Key</span>
+                </a>
+                {% endif %}
+                {% if has_p12 %}
+                <a href="/cert/download/{{ fqdn }}/p12"
+                   class="flex items-center justify-between w-full px-3 py-2 rounded border dark:border-s1-700 hover:bg-gray-50 dark:hover:bg-s1-700 transition text-sm">
+                    <span class="font-mono">{{ fqdn }}.p12</span>
+                    <span class="text-xs text-gray-500">PKCS#12</span>
+                </a>
+                {% endif %}
+                {% if not has_crt and not has_csr and not has_key and not has_p12 %}
+                    <p class="text-sm text-gray-500 text-center py-2">No files available yet.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Export PKCS#12 -->
+        <div class="bg-white dark:bg-s1-800 rounded-lg shadow p-6 border dark:border-s1-700">
+            <h3 class="text-lg font-bold mb-4">Export PKCS#12</h3>
             {% if has_crt %}
                 <form action="/cert/create_p12/{{ fqdn }}" method="POST">
-                    <label class="text-xs uppercase font-bold text-gray-500">PEM/PF12 Password</label>
-                    <input type="password" name="password" class="w-full p-2 mb-2 rounded border dark:bg-s1-900 dark:border-s1-700">
-                    <button type="submit" class="w-full py-2 bg-gray-700 hover:bg-gray-600 text-white rounded">Create .p12</button>
+                    <label class="block text-xs uppercase font-bold text-gray-500 mb-1">P12 Password</label>
+                    <input type="password" name="password" class="w-full p-2 mb-3 rounded border dark:bg-s1-900 dark:border-s1-700">
+                    <button type="submit" class="w-full py-2 bg-gray-700 hover:bg-gray-600 text-white rounded text-sm">
+                        {% if has_p12 %}Re-create{% else %}Create{% endif %} .p12
+                    </button>
                 </form>
                 {% if has_p12 %}
-                    <p class="text-xs text-green-500 mt-2 text-center">.p12 and .pem file available in directory.</p>
+                    <p class="text-xs text-green-500 mt-2 text-center">P12 bundle includes the CA chain.</p>
                 {% endif %}
             {% else %}
-                <p class="text-sm text-gray-500">Sign the certificate first to enable export options.</p>
+                <p class="text-sm text-gray-500">Sign the certificate first to enable export.</p>
             {% endif %}
         </div>
+
     </div>
 </div>
 
+<!-- Root CA Password Modal -->
 <div id="passwordModal" class="hidden fixed inset-0 bg-gray-900 bg-opacity-50 flex items-center justify-center z-50 backdrop-blur-sm">
     <div class="bg-white dark:bg-s1-800 rounded-lg shadow-xl p-6 w-96 border dark:border-s1-700">
-        <h3 class="text-lg font-bold mb-4 text-gray-900 dark:text-gray-100">Root CA Authorization</h3>
-        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Enter the Root CA password to sign <strong>{{ fqdn }}</strong>.</p>
-        
+        <h3 class="text-lg font-bold mb-2 text-gray-900 dark:text-gray-100">Root CA Authorization</h3>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-1">
+            {% if has_crt %}Re-sign{% else %}Sign{% endif %} <strong>{{ fqdn }}</strong> with the Root CA.
+        </p>
+        {% if has_crt %}
+            <p class="text-xs text-yellow-600 dark:text-yellow-400 mb-4">This will replace the existing certificate.</p>
+        {% else %}
+            <div class="mb-4"></div>
+        {% endif %}
+
         <form action="{{ url_for('sign_root', fqdn=fqdn) }}" method="POST">
-            <label class="block text-xs uppercase font-bold text-gray-500 mb-1">Password</label>
-            <input type="password" name="password" class="w-full p-2 mb-6 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white focus:ring-2 focus:ring-s1-500 outline-none" autofocus>
-            
+            <label class="block text-xs uppercase font-bold text-gray-500 mb-1">Root CA Password</label>
+            <input type="password" name="password"
+                   class="w-full p-2 mb-3 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white focus:ring-2 focus:ring-s1-500 outline-none"
+                   autofocus>
+            <label class="block text-xs uppercase font-bold text-gray-500 mb-1">Validity (days)</label>
+            <input type="number" name="days" value="365" min="1" max="3650"
+                   class="w-full p-2 mb-6 rounded border dark:bg-s1-900 dark:border-s1-700 dark:text-white focus:ring-2 focus:ring-s1-500 outline-none">
             <div class="flex justify-end space-x-3">
-                <button type="button" onclick="document.getElementById('passwordModal').classList.add('hidden')" class="px-4 py-2 rounded border dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-s1-700 text-gray-700 dark:text-gray-300 transition">Cancel</button>
-                <button type="submit" class="px-4 py-2 bg-s1-500 hover:bg-s1-400 text-white rounded shadow transition">Sign Certificate</button>
+                <button type="button"
+                        onclick="document.getElementById('passwordModal').classList.add('hidden')"
+                        class="px-4 py-2 rounded border dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-s1-700 text-gray-700 dark:text-gray-300 transition">
+                    Cancel
+                </button>
+                <button type="submit" class="px-4 py-2 bg-s1-500 hover:bg-s1-400 text-white rounded shadow transition">
+                    Sign Certificate
+                </button>
             </div>
         </form>
     </div>


### PR DESCRIPTION
## Summary

- **Client certificate support** — server/client type selector on create; `clientAuth` EKU and correct `keyUsage` set at signing time; stored in `cert.type` per cert
- **Certificate details panel** — manage page shows parsed subject, issuer, validity dates, days remaining (colour-coded), serial, EKU, and SANs once a cert is signed
- **Dashboard improvements** — cert table gains Type and Expires columns; Root CA card shows CN and expiry
- **Download routes** — `GET /cert/download/<fqdn>/<crt|key|csr|p12>` with buttons on the manage page
- **Configurable validity** — days field added to Root CA sign modal and self-sign form (default 365)
- **P12 CA chain** — P12 export now bundles the Root CA cert when the cert was signed by it

## Bug fixes

- `sign_self` was a GET route (state-changing); converted to POST
- `delete_cert` converted from GET to POST
- Root CA CN typed on dashboard was silently discarded; now pre-fills the create form
- `PF12` typo corrected to `P12`

## Test plan

- [ ] Create Root CA — verify CN pre-fill from dashboard form works
- [ ] Create server cert → sign with Root CA → check cert details panel (issuer, expiry, SANs, `serverAuth` EKU)
- [ ] Create client cert → sign with Root CA → verify `clientAuth` EKU in details panel
- [ ] Re-sign an existing cert — confirm replace warning appears and `.crt` is updated
- [ ] Self-sign with custom days value — verify expiry reflects chosen days
- [ ] Download `.crt`, `.key`, `.csr` from manage page
- [ ] Export `.p12` — import into browser/keychain and verify chain includes Root CA
- [ ] Delete cert — confirm POST form with confirm dialog works, redirects to dashboard
- [ ] Dashboard expiry column — confirm colour coding (red = expired, yellow = < 30d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)